### PR TITLE
Adding default linter path and a command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ grunt.loadNpmTasks('grunt-closure-linter');
 ### Overview
 In your project's Gruntfile, add a section named `closureLint` and/or `closureFixStyle` to the data object passed into `grunt.initConfig()`.
 
+Use the command attribute to point to a specific command if yours has not the default name.
+
 ```js
 grunt.initConfig({
   closureLint: {
     app:{
       closureLinterPath : '/path/to/closure_linter/folder',
+      command: 'gjslint',
       src: [ 'app/scripts/controllers/**',
              'app/scripts/services/**',
              'app/scripts/app.js' ],
@@ -39,6 +42,7 @@ grunt.initConfig({
   closureFixStyle: {
     app:{
       closureLinterPath : '/path/to/closure_linter/folder',
+      command: 'fixjsstyle',
       src: [ 'app/scripts/controllers/**',
              'app/scripts/services/**',
              'app/scripts/app.js' ],

--- a/tasks/closure_lint.js
+++ b/tasks/closure_lint.js
@@ -3,7 +3,7 @@
  * @copyright Patrick Bartsch 2013
  * @author Patrick Bartsch <bartsch98@gmail.com>
  * @license MIT
- * 
+ *
  * @module tasks/grunt-closure-linter
  */
 'use strict';
@@ -16,7 +16,7 @@
  */
 module.exports = function(grunt) {
 
-  var ctools = require('./lib/ctools'); 
+  var ctools = require('./lib/ctools');
   grunt.registerMultiTask('closureLint', 'Apply closure linting',
       function() {ctools.registerTool(this, 'gjslint.py');});
 };

--- a/tasks/lib/ctools.js
+++ b/tasks/lib/ctools.js
@@ -10,7 +10,7 @@ var grunt = require('grunt'),
 module.exports.registerTool = function(task, toolname) {
     var done = task.async(),
         files = [],
-        closureLinterPath = task.data.closureLinterPath,
+        closureLinterPath = task.data.closureLinterPath || '/usr/local/bin',
         options = grunt.task.current.options(
         {
           stdout : true,
@@ -18,6 +18,10 @@ module.exports.registerTool = function(task, toolname) {
           failOnError : true,
           strict : false
         });
+
+    // Toolname in options
+    toolname = task.data.command || toolname;
+
     // Iterate over all src-dest file pairs.
     task.files.forEach(function(f) {
       files = files.concat(grunt.file.expand(f.src));


### PR DESCRIPTION
This commit adds a default path for the closureLinterPath option and adds the possibility to indicate the name of your command line tool in order to avoid the 'gjslint.py' / 'gjslint' issue.
