### PR TITLE
Use path to find command

### DIFF
--- a/tasks/lib/ctools.js
+++ b/tasks/lib/ctools.js
@@ -10,7 +10,7 @@ var grunt = require('grunt'),
 module.exports.registerTool = function(task, toolname) {
     var done = task.async(),
         files = [],
-        closureLinterPath = task.data.closureLinterPath || '/usr/local/bin',
+        closureLinterPath = task.data.closureLinterPath,
         options = grunt.task.current.options(
         {
           stdout : true,
@@ -28,7 +28,7 @@ module.exports.registerTool = function(task, toolname) {
     });
     //grunt.log.writeflags(options, 'options');
 
-    var cmd = closureLinterPath + '/' + toolname;
+    var cmd = (closureLinterPath ? closureLinterPath + '/' : '') + toolname;
     cmd += options.strict ? ' --strict ' : ' ';
     // add commands to send to gjslint from option called opt
     cmd += options.opt ? options.opt + ' ' : '';


### PR DESCRIPTION
Instead of using "/usr/local/bin", don't prefix the command with any directory and let the OS find gjslint from the path environment variable.
